### PR TITLE
add dependabot

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,17 @@
+# Configure here which dependency updates should be merged automatically.
+# The recommended configuration is the following:
+- match:
+    # Only merge patches for production dependencies
+    dependency_type: production
+    update_type: "semver:patch"
+- match:
+    # Except for security fixes, here we allow minor patches
+    dependency_type: production
+    update_type: "security:minor"
+- match:
+    # and development dependencies can have a minor update, too
+    dependency_type: development
+    update_type: "semver:minor"
+
+# The syntax is based on the legacy dependabot v1 automerged_updates syntax, see:
+# https://dependabot.com/docs/config-file/#automerged_updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "04:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 15
+    versioning-strategy: increase
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "04:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 15

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+# Automatically merge Dependabot PRs when version comparison is within the range
+# that is configured in .github/auto-merge.yml
+
+name: Auto-Merge Dependabot PRs
+
+on:
+  # WARNING: This needs to be run in the PR base, DO NOT build untrusted code in this action
+  # details under https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+  pull_request_target:
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Check if PR should be auto-merged
+        uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          # In order to use this, you need to go to https://github.com/settings/tokens and
+          # create a Personal Access Token with the permission "public_repo".
+          # Enter this token in your repository settings under "Secrets" and name it AUTO_MERGE_TOKEN
+          github-token: ${{ secrets.AUTO_MERGE_TOKEN }}
+          # By default, squash and merge, so Github chooses nice commit messages
+          command: squash and merge


### PR DESCRIPTION
This PR adds dependabot support.

Please note the following actions to be done by you if you want to use automerge

```
          # In order to use this, you need to go to https://github.com/settings/tokens and
          # create a Personal Access Token with the permission "public_repo".
          # Enter this token in your repository settings under "Secrets" and name it AUTO_MERGE_TOKEN
```
Automerge - if enabled - merges patch releases without further action required by you.